### PR TITLE
Add --count and --start-at options to logs command, enable strict option parsing

### DIFF
--- a/docs-site/docs/commands/logs.md
+++ b/docs-site/docs/commands/logs.md
@@ -5,7 +5,7 @@ Show recent logs for service(s).
 ## Syntax
 
 ```bash
-candle logs [name...]
+candle logs [name...] [--count <number>] [--start-at <id>]
 ```
 
 ## Description
@@ -17,6 +17,11 @@ This can include logs from previous launches, or logs for services that aren't r
 ## Arguments
 
 - `name` - Name of the service(s) to view logs for. Can specify multiple services.
+
+## Options
+
+- `--count <number>` - Number of log lines to show. Default: 100.
+- `--start-at <id>` - Only show logs after this log ID. Useful for pagination.
 
 ## Examples
 
@@ -30,6 +35,18 @@ candle logs api
 
 ```bash
 candle logs api web
+```
+
+### Show only the last 10 log lines
+
+```bash
+candle logs api --count 10
+```
+
+### Show logs after a specific log ID
+
+```bash
+candle logs api --start-at 500
 ```
 
 ## See Also

--- a/src/logs-command.ts
+++ b/src/logs-command.ts
@@ -6,10 +6,11 @@ interface LogsCommandOptions {
   projectDir: string;
   commandNames: string[];
   limit?: number; // Number of log lines to show
+  startAtId?: number; // Only show logs after this log ID
 }
 
 export async function handleLogsCommand(req: LogsCommandOptions): Promise<void> {
-  const { projectDir, commandNames, limit = 100 } = req;
+  const { projectDir, commandNames, limit = 100, startAtId } = req;
 
   const isBlendedMode = commandNames.length !== 1;
 
@@ -18,6 +19,7 @@ export async function handleLogsCommand(req: LogsCommandOptions): Promise<void> 
     projectDir,
     commandNames: commandNames.length > 0 ? commandNames : undefined,
     limit,
+    afterLogId: startAtId,
   });
 
   const logFilter = new LatestExecutionLogFilter({ showPastLogsBehavior: 'show_logs_from_previous_launch' });

--- a/src/main-cli.ts
+++ b/src/main-cli.ts
@@ -122,12 +122,13 @@ function configureYargs() {
     })
 
     // Help and MCP commands
-    .command('help [topic]', 'Show help', () => {})
-    .command('mcp', 'Enter MCP server mode', () => {})
+    .command('help [topic]', 'Show help', (yargs: Argv) => { yargs.positional('topic', { type: 'string' }).strictOptions(); })
+    .command('mcp', 'Enter MCP server mode', (yargs: Argv) => { yargs.strictOptions(); })
 
     // Process Management
     .command('run [name...]', 'Launch process(es) and watch their output', (yargs: Argv) => {
       yargs
+        .positional('name', { type: 'string' })
         .option('shell', {
           describe: 'Shell command for transient process',
           type: 'string',
@@ -139,10 +140,12 @@ function configureYargs() {
         .option('enable-stdin', {
           describe: 'Enable stdin message polling from database',
           type: 'boolean',
-        });
+        })
+        .strictOptions();
     })
     .command('start [name...]', 'Start process(es) in background and exit', (yargs: Argv) => {
       yargs
+        .positional('name', { type: 'string' })
         .option('shell', {
           describe: 'Shell command for transient process',
           type: 'string',
@@ -154,17 +157,31 @@ function configureYargs() {
         .option('enable-stdin', {
           describe: 'Enable stdin message polling from database',
           type: 'boolean',
-        });
+        })
+        .strictOptions();
     })
-    .command('restart [name]', 'Restart a running process', () => {})
-    .command('kill [name...]', 'Kill process(es) in the current directory', () => {})
-    .command('kill-all', 'Kill all running processes', () => {})
-    .command(['list', 'ls'], 'List processes for current directory', () => {})
-    .command('list-all', 'List all processes', () => {})
-    .command('logs [name...]', 'Show recent logs for process(es)', () => {})
-    .command('watch [name...]', 'Watch live output from process(es)', () => {})
+    .command('restart [name]', 'Restart a running process', (yargs: Argv) => { yargs.positional('name', { type: 'string' }).strictOptions(); })
+    .command('kill [name...]', 'Kill process(es) in the current directory', (yargs: Argv) => { yargs.positional('name', { type: 'string' }).strictOptions(); })
+    .command('kill-all', 'Kill all running processes', (yargs: Argv) => { yargs.strictOptions(); })
+    .command(['list', 'ls'], 'List processes for current directory', (yargs: Argv) => { yargs.strictOptions(); })
+    .command('list-all', 'List all processes', (yargs: Argv) => { yargs.strictOptions(); })
+    .command('logs [name...]', 'Show recent logs for process(es)', (yargs: Argv) => {
+      yargs
+        .positional('name', { type: 'string' })
+        .option('count', {
+          describe: 'Number of log lines to show (default: 100)',
+          type: 'number',
+        })
+        .option('start-at', {
+          describe: 'Only show logs after this log ID',
+          type: 'number',
+        })
+        .strictOptions();
+    })
+    .command('watch [name...]', 'Watch live output from process(es)', (yargs: Argv) => { yargs.positional('name', { type: 'string' }).strictOptions(); })
     .command('wait-for-log [name]', 'Wait for a specific log message', (yargs: Argv) => {
       yargs
+        .positional('name', { type: 'string' })
         .option('message', {
           describe: 'The log message to wait for',
           type: 'string',
@@ -174,19 +191,20 @@ function configureYargs() {
           describe: 'Timeout in seconds (default: 30)',
           type: 'number',
           default: 30,
-        });
+        })
+        .strictOptions();
     })
-    .command('list-ports [name]', 'List open ports for running services', () => {})
-    .command('list-ports-all', 'List open ports for all services', () => {})
-    .command('open-browser [name]', 'Open browser to a running service (auto-detects if only one running)', () => {})
+    .command('list-ports [name]', 'List open ports for running services', (yargs: Argv) => { yargs.positional('name', { type: 'string' }).strictOptions(); })
+    .command('list-ports-all', 'List open ports for all services', (yargs: Argv) => { yargs.strictOptions(); })
+    .command('open-browser [name]', 'Open browser to a running service (auto-detects if only one running)', (yargs: Argv) => { yargs.positional('name', { type: 'string' }).strictOptions(); })
 
     // Port Reservations
-    .command('reserve-port [name]', 'Reserve an unused port', () => {})
-    .command('release-ports [name]', 'Release reserved port(s)', () => {})
-    .command('list-reserved-ports', 'List reserved ports for project', () => {})
-    .command('list-reserved-ports-all', 'List all reserved ports', () => {})
-    .command('get-reserved-port <name>', 'Get the reserved port for a service', () => {})
-    .command('get-or-reserve-port <name>', 'Get existing or reserve new port for a service', () => {})
+    .command('reserve-port [name]', 'Reserve an unused port', (yargs: Argv) => { yargs.positional('name', { type: 'string' }).strictOptions(); })
+    .command('release-ports [name]', 'Release reserved port(s)', (yargs: Argv) => { yargs.positional('name', { type: 'string' }).strictOptions(); })
+    .command('list-reserved-ports', 'List reserved ports for project', (yargs: Argv) => { yargs.strictOptions(); })
+    .command('list-reserved-ports-all', 'List all reserved ports', (yargs: Argv) => { yargs.strictOptions(); })
+    .command('get-reserved-port <name>', 'Get the reserved port for a service', (yargs: Argv) => { yargs.positional('name', { type: 'string' }).strictOptions(); })
+    .command('get-or-reserve-port <name>', 'Get existing or reserve new port for a service', (yargs: Argv) => { yargs.positional('name', { type: 'string' }).strictOptions(); })
 
     // Configuration & Maintenance
     .command('add-service <name>', 'Add a new service to .candle.json', (yargs: Argv) => {
@@ -207,12 +225,13 @@ function configureYargs() {
         .option('enable-stdin', {
           describe: 'Enable stdin message polling from database',
           type: 'boolean',
-        });
+        })
+        .strictOptions();
     })
-    .command('clear-logs [name]', 'Clear logs for process(es)', () => {})
-    .command('erase-database', 'Erase the Candle database', () => {})
-    .command('list-docs', 'List available documentation', () => {})
-    .command('get-doc <name>', 'Display a documentation file', () => {})
+    .command('clear-logs [name]', 'Clear logs for process(es)', (yargs: Argv) => { yargs.positional('name', { type: 'string' }).strictOptions(); })
+    .command('erase-database', 'Erase the Candle database', (yargs: Argv) => { yargs.strictOptions(); })
+    .command('list-docs', 'List available documentation', (yargs: Argv) => { yargs.strictOptions(); })
+    .command('get-doc <name>', 'Display a documentation file', (yargs: Argv) => { yargs.positional('name', { type: 'string' }).strictOptions(); })
 
     .demandCommand(0, 'You need to specify a command')
     .help(false)  // Disable default help, we'll handle it
@@ -238,6 +257,8 @@ function parseArgs(): {
   message?: string;
   timeout?: number;
   topic?: string;
+  count?: number;
+  startAt?: number;
 } {
   const argv = configureYargs().parseSync();
 
@@ -254,8 +275,10 @@ function parseArgs(): {
   const message = argv.message as string;
   const timeout = argv.timeout as number;
   const topic = argv.topic as string;
+  const count = argv.count as number;
+  const startAt = argv['start-at'] as number;
 
-  return { command, commandNames, mcp, shell, root, enableStdin, message, timeout, topic };
+  return { command, commandNames, mcp, shell, root, enableStdin, message, timeout, topic, count, startAt };
 }
 
 export async function main(): Promise<void> {
@@ -282,7 +305,7 @@ export async function main(): Promise<void> {
     return;
   }
 
-  const { command, commandNames, mcp, shell, root, enableStdin, message, timeout, topic } =
+  const { command, commandNames, mcp, shell, root, enableStdin, message, timeout, topic, count, startAt } =
     parseArgs();
 
   // Check if no arguments - print help
@@ -434,6 +457,8 @@ export async function main(): Promise<void> {
       await handleLogsCommand({
         projectDir,
         commandNames,
+        limit: count,
+        startAtId: startAt,
       });
       break;
     }

--- a/test/cli/errors.test.ts
+++ b/test/cli/errors.test.ts
@@ -22,6 +22,32 @@ describe('CLI Error Handling', () => {
         });
     });
 
+    describe('unrecognized flags (strict mode)', () => {
+        it('should error for unrecognized flag on logs command', async () => {
+            const result = await workspace.runCli(['logs', '--unknown'], { ignoreExitCode: true });
+
+            expect(result.failed()).toBe(true);
+            const output = result.stdoutAsString() + result.stderrAsString();
+            expect(output).toContain('Unknown argument');
+        });
+
+        it('should error for unrecognized flag on list command', async () => {
+            const result = await workspace.runCli(['list', '--bad-flag'], { ignoreExitCode: true });
+
+            expect(result.failed()).toBe(true);
+            const output = result.stdoutAsString() + result.stderrAsString();
+            expect(output).toContain('Unknown argument');
+        });
+
+        it('should error for unrecognized flag on start command', async () => {
+            const result = await workspace.runCli(['start', 'echo', '--nonexistent'], { ignoreExitCode: true });
+
+            expect(result.failed()).toBe(true);
+            const output = result.stdoutAsString() + result.stderrAsString();
+            expect(output).toContain('Unknown argument');
+        });
+    });
+
     describe('missing required arguments', () => {
         it('should error when add-service missing arguments', async () => {
             const result = await workspace.runCli(['add-service'], { ignoreExitCode: true });

--- a/test/cli/help.test.ts
+++ b/test/cli/help.test.ts
@@ -130,6 +130,8 @@ describe('CLI Help Command', () => {
             const result = await workspace.runCli(['logs', '--help']);
 
             expect(result.stdoutAsString()).toContain('logs');
+            expect(result.stdoutAsString()).toContain('--count');
+            expect(result.stdoutAsString()).toContain('--start-at');
         });
 
         it('should show help for wait-for-log command', async () => {


### PR DESCRIPTION
Implements GitHub issue #7: support --count and --start-at options for logs.

- --count controls how many log lines to show (default: 100)
- --start-at shows only logs after a given log ID, enabling pagination
- Enable strictOptions() on all CLI commands so unrecognized flags
  produce a clear error instead of being silently ignored
- Add tests for new flags and strict mode validation
- Update logs command documentation with new options and examples

https://claude.ai/code/session_01R7nKSbrEUMyCENcXavEoao