### PR TITLE
Improve open-browser error message when no ports found

### DIFF
--- a/src/main-cli.ts
+++ b/src/main-cli.ts
@@ -366,8 +366,9 @@ export async function main(): Promise<void> {
     }
 
     case 'open-browser': {
+      const projectDir = findProjectDir();
       const serviceName = commandNames[0];
-      const output = await handleOpenBrowser({ serviceName });
+      const output = await handleOpenBrowser({ projectDir, serviceName });
       printOpenBrowserOutput(output);
       break;
     }

--- a/src/mcp/mcp-main.ts
+++ b/src/mcp/mcp-main.ts
@@ -122,7 +122,8 @@ const toolDefinitions: ToolDefinition[] = [
       if (!serviceName) {
         throw new McpError(ErrorCode.InvalidRequest, 'Service name is required');
       }
-      const result = await handleOpenBrowser({ serviceName });
+      const projectDir = findProjectDir();
+      const result = await handleOpenBrowser({ projectDir, serviceName });
       return result;
     },
   },

--- a/src/open-browser-command.ts
+++ b/src/open-browser-command.ts
@@ -2,10 +2,10 @@ import { spawn } from 'child_process';
 import { platform } from 'os';
 import { handleListPorts } from './list-ports-command.ts';
 import { UsageError } from './errors.ts';
-import { findConfigFile } from './configFile.ts';
-import { findProcessesByProjectDir } from './database/processTable.ts';
+import { findProcessesByCommandNameAndProjectDir, findProcessesByProjectDir } from './database/processTable.ts';
 
 export interface OpenBrowserOptions {
+  projectDir: string;
   serviceName?: string;
 }
 
@@ -15,13 +15,11 @@ export interface OpenBrowserOutput {
   url: string;
 }
 
-function resolveServiceName(providedName?: string): string {
+function resolveServiceName(projectDir: string, providedName?: string): string {
   if (providedName) {
     return providedName;
   }
 
-  // Auto-detect: find running processes in the current project
-  const { projectDir } = findConfigFile(process.cwd());
   const runningProcesses = findProcessesByProjectDir(projectDir);
 
   if (runningProcesses.length === 0) {
@@ -43,14 +41,24 @@ function resolveServiceName(providedName?: string): string {
 export async function handleOpenBrowser(
   options: OpenBrowserOptions
 ): Promise<OpenBrowserOutput> {
-  const serviceName = resolveServiceName(options.serviceName);
+  const { projectDir } = options;
+  const serviceName = resolveServiceName(projectDir, options.serviceName);
 
   const portsOutput = await handleListPorts({ commandNames: [serviceName] });
 
   if (portsOutput.ports.length === 0) {
-    throw new UsageError(
-      `No open ports found for service '${serviceName}'. Is the service running?`
-    );
+    const processes = findProcessesByCommandNameAndProjectDir(serviceName, projectDir);
+    const isRunning = processes.some(p => p.killed_at === null);
+
+    if (isRunning) {
+      throw new UsageError(
+        `No open ports found for service '${serviceName}'.`
+      );
+    } else {
+      throw new UsageError(
+        `No open ports found for service '${serviceName}'. Start the service with: candle start`
+      );
+    }
   }
 
   const sortedPorts = [...portsOutput.ports].sort((a, b) => a.port - b.port);


### PR DESCRIPTION
## Summary

- When `open-browser` finds no ports, the error message now checks whether the service is actually running
- If running: shows "No open ports found for service 'X'." (no misleading "Is the service running?" question)
- If not running: shows "No open ports found for service 'X'. Start the service with: candle start"
- Refactored `handleOpenBrowser` to accept `projectDir` from the caller, matching the pattern used by other commands and eliminating a duplicate `findConfigFile` call