### PR TITLE
Fix bugs and update documentation for Candle CLI

### DIFF
--- a/docs-site/docs/commands/check-start.md
+++ b/docs-site/docs/commands/check-start.md
@@ -22,6 +22,7 @@ Compared to `start`, which always kills and restarts a running service, `check-s
 
 - `--shell <command>` - Start a transient service with the specified shell command
 - `--root <directory>` - Set the working directory for a transient service
+- `--enable-stdin` - Enable stdin message polling from database
 
 ## Examples
 

--- a/docs-site/docs/commands/kill.md
+++ b/docs-site/docs/commands/kill.md
@@ -10,7 +10,7 @@ candle kill [name...]
 
 ## Description
 
-The `kill` command stops running services.
+The `kill` command stops running services. `candle stop` is an alias for this command.
 
 When called without arguments, it kills all services in the current project directory.
 

--- a/docs-site/docs/commands/restart.md
+++ b/docs-site/docs/commands/restart.md
@@ -1,20 +1,20 @@
 # restart
 
-Restart a running service.
+Restart running service(s).
 
 ## Syntax
 
 ```bash
-candle restart [name]
+candle restart [name...]
 ```
 
 ## Description
 
-The `restart` command stops a running service and starts it again.
+The `restart` command stops running service(s) and starts them again.
 
 ## Arguments
 
-- `name` - Name of the service to restart. If omitted, restarts all running services in the current project directory.
+- `name` - Name of the service(s) to restart. If omitted, restarts all running services in the current project directory.
 
 ## Examples
 

--- a/docs-site/docs/commands/run.md
+++ b/docs-site/docs/commands/run.md
@@ -28,6 +28,7 @@ The `run` and `start` commands are similar, the main differences are:
 
 - `--shell <command>` - Override the shell command. Can be used for transient services.
 - `--root <directory>` - Override the working directory. Can be used for transient services.
+- `--enable-stdin` - Enable stdin message polling from database
 
 ## Examples
 

--- a/docs-site/docs/commands/start.md
+++ b/docs-site/docs/commands/start.md
@@ -29,6 +29,7 @@ After running `start` you can check on the service using the `watch` or `logs` c
 
 - `--shell <command>` - Start a transient service with the specified shell command
 - `--root <directory>` - Set the working directory for a transient service
+- `--enable-stdin` - Enable stdin message polling from database
 
 ## Examples
 

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -124,7 +124,7 @@ When viewing logs, Candle displays a `-- older logs have been removed --` indica
 You can add services without manually editing the config file:
 
 ```bash
-candle add-service api "npm run dev" --root packages/api
+candle add-service api --shell "npm run dev" --root packages/api
 ```
 
 This will create or update `.candle.json` with the new service.

--- a/docs-site/docs/getting-started.md
+++ b/docs-site/docs/getting-started.md
@@ -7,13 +7,13 @@ This guide will help you install Candle and set up your first project.
 Install Candle globally using npm:
 
 ```bash
-npm install -g candle
+npm install -g @facetlayer/candle
 ```
 
 Or using pnpm:
 
 ```bash
-pnpm add -g candle
+pnpm add -g @facetlayer/candle
 ```
 
 ## Configure a service
@@ -21,7 +21,7 @@ pnpm add -g candle
 Use the `add-service` command to add a new configured service:
 
 ```bash
-candle add-service api "npm run dev"
+candle add-service api --shell "npm run dev"
 ```
 
 This will create a `.candle.json` file in the current directory.

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -15,7 +15,7 @@ Candle is a lightweight process manager designed for local development. It allow
 
 ```bash
 # Install globally
-npm install -g candle
+npm install -g @facetlayer/candle
 
 # Create a config file
 echo '{"services": [{"name": "api", "shell": "npm run dev"}]}' > .candle.json

--- a/src/kill/killOneRunningProcess.ts
+++ b/src/kill/killOneRunningProcess.ts
@@ -27,7 +27,7 @@ export async function killOneRunningProcess(process: ServiceInfo, options: KillP
       // If the killed_at date is over 5 minutes old, delete the stale entry.
       // This can happen if the entry fails to get cleaned up.
 
-      if (process.killed_at && process.killed_at < Date.now() - 5 * 60 * 1000) {
+      if (process.killed_at && process.killed_at < Math.floor(Date.now() / 1000) - 5 * 60) {
         if (!options.quiet) {
           console.warn(
             `[Cleaning up stale process entry for '${process.command_name}' with PID: ${process.pid}]`

--- a/src/kill/killProcessTree.ts
+++ b/src/kill/killProcessTree.ts
@@ -4,7 +4,7 @@ type KillProcessTreeResult = 'success' | 'process_not_found' | 'error';
 
 export async function killProcessTree(pid: number): Promise<KillProcessTreeResult> {
   if (pid == null || pid == 0) {
-    throw new Error(`internal error: tryKillProcessTree called with invalid PID: ${pid}`);
+    throw new Error(`internal error: killProcessTree called with invalid PID: ${pid}`);
   }
 
   const pids = await getProcessTree(pid);

--- a/src/logs/ProcessLogType.ts
+++ b/src/logs/ProcessLogType.ts
@@ -2,7 +2,7 @@ export const ProcessLogType = {
   stdout: 1,
   stderr: 2,
 
-  // process_start_initiated - Saved immediately when we being launching a subprocess
+  // process_start_initiated - Saved immediately when we begin launching a subprocess
   process_start_initiated: 3,
 
   // process_start_failed - Saved when the subprocess fails to start.

--- a/src/mcp/mcp-main.ts
+++ b/src/mcp/mcp-main.ts
@@ -274,7 +274,7 @@ const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'AddServerConfig',
-    description: 'Add a new server configuration to .candle-setup.json',
+    description: 'Add a new server configuration to .candle.json',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/start/startOneService.ts
+++ b/src/start/startOneService.ts
@@ -59,7 +59,7 @@ export async function startOneService(req: RunOptions): Promise<StartResult> {
   if (req.shell) {
     // Transient process - use provided shell/root
     if (!req.commandName) {
-      throw new UsageError('Commad name is required');
+      throw new UsageError('Command name is required');
     }
 
     // Validate root if provided

--- a/test/cli/check-start.test.ts
+++ b/test/cli/check-start.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import { TestWorkspace } from './utils';
 
-const workspace = new TestWorkspace('cli-start');
+const workspace = new TestWorkspace('cli-check-start');
 
 describe('CLI Check-Start Command', () => {
     beforeAll(() => workspace.ensureSubdir('test'));

--- a/test/cli/wait-for-log.test.ts
+++ b/test/cli/wait-for-log.test.ts
@@ -132,7 +132,7 @@ describe('CLI Wait-For-Log Command', () => {
             // Should have some indication of timeout
             const output = result.stdoutAsString() + result.stderrAsString();
             expect(output.toLowerCase()).toMatch(/timeout|not found|failed/);
-        }, 5000);
+        }, 15000);
     });
 
     describe('wait-for-log exit behavior', () => {

--- a/test/workspaces/cli-check-start/.candle.json
+++ b/test/workspaces/cli-check-start/.candle.json
@@ -1,0 +1,16 @@
+{
+  "services": [
+    {
+      "name": "web",
+      "shell": "node ../../sampleServers/testProcess.js"
+    },
+    {
+      "name": "echo",
+      "shell": "node ../../sampleServers/echoServer.js"
+    },
+    {
+      "name": "echo-test",
+      "shell": "node ../../sampleServers/echoServer.js"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
This PR addresses several bug fixes, documentation updates, and test improvements across the Candle codebase.

## Key Changes

### Bug Fixes
- **Timestamp comparison fix** (`killOneRunningProcess.ts`): Corrected timestamp comparison logic to use consistent units (seconds) when checking if a stale process entry should be cleaned up
- **Error message fix** (`killProcessTree.ts`): Updated error message to reference correct function name (`killProcessTree` instead of `tryKillProcessTree`)
- **Typo fixes**: 
  - Fixed "Commad" → "Command" in error message (`startOneService.ts`)
  - Fixed "being launching" → "begin launching" in comment (`ProcessLogType.ts`)
  - Fixed MCP tool description from `.candle-setup.json` → `.candle.json` (`mcp-main.ts`)

### Documentation Updates
- Updated installation instructions to use scoped package name (`@facetlayer/candle`)
- Updated `add-service` command examples to use `--shell` flag syntax
- Updated `restart` command documentation to clarify it handles multiple services
- Added clarification that `candle stop` is an alias for `candle kill`
- Added `--enable-stdin` option documentation to `start`, `run`, and `check-start` commands

### Test Improvements
- Fixed test workspace reference from `cli-start` to `cli-check-start` to match actual workspace directory
- Increased timeout for `wait-for-log` test from 5s to 15s to reduce flakiness
- Added test workspace configuration file (`.candle.json`) for `cli-check-start`

## Implementation Details
- All changes maintain backward compatibility
- Documentation updates align with actual CLI behavior and package naming
- Bug fixes address edge cases in process management and error handling

https://claude.ai/code/session_01FicZAPVifW9LbLCtmWsJ5c