### PR TITLE
docs: fix outdated and incorrect documentation

### DIFF
--- a/docs-site/docs/commands/mcp.md
+++ b/docs-site/docs/commands/mcp.md
@@ -25,6 +25,7 @@ When running as an MCP server, the following tools are available:
 - `RestartService` - Restart a service
 - `GetLogs` - Get recent logs for a service
 - `ListPorts` - List open ports for running services
+- `OpenBrowser` - Open a browser window to a running service's port
 - `AddServerConfig` - Add a service to configuration
 
 ## Examples

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -54,11 +54,10 @@ The shell command to execute when starting the service.
 
 ### root (optional)
 
-A relative directory path where the command will run. Must be relative to the config file location.
+A directory path where the command will run. Relative paths are resolved against the config file location. Absolute paths are also supported.
 
 **Constraints:**
-- Cannot be an absolute path
-- Cannot use `..` to escape the project directory
+- If relative, cannot use `..` to escape the project directory
 
 ```json
 {

--- a/docs-site/docs/database.md
+++ b/docs-site/docs/database.md
@@ -9,7 +9,12 @@ Usually you don't need to interact with this database directly, but it's there f
 
 ## Location
 
-By default the database is stored at `~/.local/state/candle/candle.db`. This location can change based on your `XDG_STATE_HOME` environment variable.
+By default the database is stored at `~/.local/state/candle/candle.db`.
+
+The location can be changed via environment variables:
+
+- `CANDLE_DATABASE_DIR` - Overrides the database directory entirely. This is useful for testing or running isolated instances.
+- `XDG_STATE_HOME` - If set (and `CANDLE_DATABASE_DIR` is not), the database is stored at `$XDG_STATE_HOME/candle/candle.db`.
 
 ## Commands
 

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -54,12 +54,15 @@ candle run server --shell "python -m http.server 8080"
 |---------|-------------|
 | [`run`](commands/run) | Start service(s) and watch their output |
 | [`start`](commands/start) | Start service(s) in the background |
+| [`check-start`](commands/check-start) | Start service(s) only if not already running |
 | [`restart`](commands/restart) | Restart running service(s) |
 | [`kill`](commands/kill) | Stop running service(s) |
 | [`list`](commands/list) | List active services |
 | [`logs`](commands/logs) | View recent logs |
 | [`watch`](commands/watch) | Watch live service output |
 | [`wait-for-log`](commands/wait-for-log) | Wait for a specific log message |
+| [`list-ports`](commands/list-ports) | List open ports for running services |
+| [`open-browser`](commands/open-browser) | Open a browser to a running service |
 
 ## See Also
 

--- a/docs-site/docs/mcp-integration.md
+++ b/docs-site/docs/mcp-integration.md
@@ -60,6 +60,21 @@ Restart a running service.
 **Parameters:**
 - `name` (string, optional) - Name of the service to restart. If not provided, restarts all running services.
 
+### ListPorts
+
+List open (listening) ports for running services.
+
+**Parameters:**
+- `showAll` (boolean, optional) - Show ports for all services globally, not just current directory
+- `serviceName` (string, optional) - Filter to a specific service name
+
+### OpenBrowser
+
+Open a browser window to a running service's listening port.
+
+**Parameters:**
+- `serviceName` (string, required) - Name of the service to open in the browser
+
 ### AddServerConfig
 
 Add a new server configuration to the config file.
@@ -82,7 +97,7 @@ To use Candle with Claude Code, add it to your MCP configuration. Claude Code ca
 
 Before using MCP tools, you'll typically want to configure your services. You can do this via:
 
-- The CLI: `candle add-service api "npm run dev"`
+- The CLI: `candle add-service api --shell "npm run dev"`
 - The MCP `AddServerConfig` tool (see above)
 
 See [add-service](commands/add-service) for CLI usage details.

--- a/docs-site/sidebars.js
+++ b/docs-site/sidebars.js
@@ -23,6 +23,7 @@ const sidebars = {
       items: [
         {type: 'doc', id: 'commands/run', label: 'run'},
         {type: 'doc', id: 'commands/start', label: 'start'},
+        {type: 'doc', id: 'commands/check-start', label: 'check-start'},
         {type: 'doc', id: 'commands/restart', label: 'restart'},
         {type: 'doc', id: 'commands/kill', label: 'kill'},
         {type: 'doc', id: 'commands/list', label: 'list / ls'},

--- a/docs/agents-intro.md
+++ b/docs/agents-intro.md
@@ -16,7 +16,7 @@ of the nearest `.candle.json` file).
 # Basic commands:
 
  - See what services are available: `candle ls`
- - Start a service in the background: `candle run <service-name>`
+ - Start a service in the background: `candle start <service-name>`
  - Browse logs: `candle logs` or `candle logs <service-name>`
  - Configure a new service: `candle add-service <service-name> --shell <shell>`
  - Kill a service: `candle kill <service-name>`
@@ -25,10 +25,12 @@ of the nearest `.candle.json` file).
 
 More commands are available by running: `candle help`
 
-Candle can also help with localhost port reservations, see: `candle help port-reservation`
-
 # Commands to avoid
 
 Do NOT use these commands: `candle run` or `candle watch`. These are interactive commands
 and they will block your execution until killed. Use other commands like `candle start`
 or `candle logs` instead.
+
+Note: When Candle detects that it's being run by an AI agent (via the `CLAUDECODE`
+environment variable), these interactive commands are hidden from `--help` and will
+refuse to run.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,15 +43,17 @@ Services are defined in a `.candle.json` file in your project directory:
 
 ```json
 {
-  "services": {
-    "api": {
+  "services": [
+    {
+      "name": "api",
       "shell": "npm run dev"
     },
-    "worker": {
+    {
+      "name": "worker",
       "shell": "npm run worker",
       "root": "./packages/worker"
     }
-  }
+  ]
 }
 ```
 

--- a/docs/transient-processes.md
+++ b/docs/transient-processes.md
@@ -52,7 +52,7 @@ candle start web --shell "node other-server.js"
 ### Visibility in `ls`
 
 - Transient processes appear in `candle ls` while running
-- When killed, they disappear from the list (unlike config-defined services which show as "NOT LAUNCHED")
+- When killed, they disappear from the list (unlike config-defined services, which continue to appear with a "not running" status)
 - If a transient process shadows a config-defined service, `ls` will show a `[config changed]` warning
 
 ### Restart Behavior


### PR DESCRIPTION
## Summary

Read through all project documentation (both `docs-site/` public docs and internal `docs/`) and validated claims against the source code. This PR fixes the mismatches that were found.

## Changes

**Public docs (`docs-site/`):**

- `mcp-integration.md` — Added missing MCP tools `ListPorts` and `OpenBrowser`. They are registered in `src/mcp/mcp-main.ts` but were never documented.
- `commands/mcp.md` — Added `OpenBrowser` to the tool list.
- `configuration.md` — Removed the incorrect "Cannot be an absolute path" constraint on `root`. `configFile.ts:isValidRootPath` explicitly returns `true` for absolute paths.
- `database.md` — Documented the `CANDLE_DATABASE_DIR` environment variable (it takes precedence over `XDG_STATE_HOME`; see `src/dirs.ts:getStateDirectory`).
- `index.md` — Added `check-start`, `list-ports`, and `open-browser` to the Commands Overview table.
- `sidebars.js` — Added the existing `commands/check-start` doc to the sidebar (the file existed but was unreachable from the nav).
- `mcp-integration.md` — Fixed the `add-service` CLI example to include the required `--shell` flag.

**Internal docs (`docs/`):**

- `agents-intro.md` — Fixed "Start a service in the background" example (was `candle run`, which watches logs; should be `candle start`). Removed the reference to `candle help port-reservation` (port reservation was removed in 0.12.0 per `CHANGELOG.md`). Added a note that `run`/`watch` are blocked when the `CLAUDECODE` env var is set.
- `getting-started.md` — Replaced the deprecated object-form `services: { api: { ... } }` example with the canonical array form (`services: [{ name: "api", ... }]`). The object form is still accepted by the validator for backwards compatibility but the public docs and codebase use the array form.
- `transient-processes.md` — Corrected the stated inactive-service status. The code prints `not running` (see `src/list-command.ts:123`), not `NOT LAUNCHED`.

## Test plan

- [x] `git diff` reviewed — 9 files, 41 insertions, 13 deletions, all doc-only
- [x] Each incorrect claim was cross-checked against the relevant source file before changing
- [ ] Docusaurus site builds cleanly (not run locally — only Markdown/JS config changes, no new doc files referenced)

https://claude.ai/code/session_01Sk4ZaUutmwQRnky36KWaAj